### PR TITLE
Fix scrollbars on the homepage

### DIFF
--- a/apps/site/pages/_app.tsx
+++ b/apps/site/pages/_app.tsx
@@ -36,7 +36,7 @@ export default function App({ Component, pageProps }: AppProps) {
           defaultTheme={theme}
         >
           <Theme name={theme}>
-            <Stack bc="$background" minHeight="100vh" minWidth="100vw">
+            <Stack bc="$background" minHeight="100%" minWidth="100%">
               {contents}
             </Stack>
           </Theme>


### PR DESCRIPTION
vw/vh units include the scrollbars. Nearly always you want to use % instead.

Before:
![Before screenshot of the homepage with unnecessary scrollbar](https://github.com/G-Ray/pikatorrent/assets/38681822/8cc7b015-e898-4033-b621-301ab6e692cf)

After:
![After screenshot of the homepage without the unnecessary scrollbar](https://github.com/G-Ray/pikatorrent/assets/38681822/eee97ebc-2d63-49ab-8fa9-411431fead7e)
